### PR TITLE
Fix addNext queue expansion

### DIFF
--- a/src/Playlist.java
+++ b/src/Playlist.java
@@ -133,7 +133,9 @@ public class Playlist {
     public void addNext(Song song) {
         int prio = 0;
 
-        if (sizes[prio] >= MAX_SONGS) return;
+        if (sizes[prio] == queues[prio].length) {
+            queues[prio] = expandArray(queues[prio]);
+        }
 
         int insertIndex = 0;
 


### PR DESCRIPTION
## Summary
- ensure `addNext` can grow the priority queue when it becomes full

## Testing
- `javac src/*.java`
- custom test program adding more than 1000 songs via `addNext`

------
https://chatgpt.com/codex/tasks/task_e_684c353b47dc832db9059053ea626a18