### PR TITLE
Fix next insertion

### DIFF
--- a/src/Playlist.java
+++ b/src/Playlist.java
@@ -137,13 +137,8 @@ public class Playlist {
 
         int insertIndex = 0;
 
-        // Wenn currentSong mit Prio 0 gerade läuft → insertIndex = 1
-        if (currentSong != null && currentSong.getPriority() == prio) {
-            insertIndex = 1;
-        }
-
-        for (int i = sizes[prio]; i > insertIndex; i--) {
-            queues[prio][i] = queues[prio][i - 1];
+        for (int i = sizes[prio] - 1; i >= insertIndex; i--) {
+            queues[prio][i + 1] = queues[prio][i];
         }
 
         queues[prio][insertIndex] = song;


### PR DESCRIPTION
## Summary
- update `addNext` logic so songs are always inserted at the start of the priority-0 queue

## Testing
- `javac src/*.java`


------
https://chatgpt.com/codex/tasks/task_e_684c353bb834832d8d1ab565da14d1b3