### PR TITLE
Move printing logic out of Playlist

### DIFF
--- a/src/HistoryCommand.java
+++ b/src/HistoryCommand.java
@@ -10,6 +10,8 @@ public class HistoryCommand implements Command {
 
     @Override
     public void execute(String input, Playlist playlist) {
-        playlist.history();
+        for (String s : playlist.history()) {
+            System.out.println(s);
+        }
     }
 }

--- a/src/ListCommand.java
+++ b/src/ListCommand.java
@@ -10,6 +10,8 @@ public class ListCommand implements Command {
 
     @Override
     public void execute(String input, Playlist playlist) {
-        playlist.list();
+        for (String s : playlist.list()) {
+            System.out.println(s);
+        }
     }
 }

--- a/src/Playlist.java
+++ b/src/Playlist.java
@@ -2,6 +2,9 @@
  * Manages all songs, queues and playback operations of the application.
  * @author ujnaa
  */
+import java.util.ArrayList;
+import java.util.List;
+
 public class Playlist {
     /** maximum number of songs for history and initial queue sizes */
     private static final int MAX_SONGS = 1000;
@@ -49,12 +52,16 @@ public class Playlist {
     }
 
     /**
-     * Prints all songs that have been played so far in order of playtime.
+     * Returns all songs that have been played so far in order of playtime.
+     *
+     * @return list of formatted song strings
      */
-    public void history() {
+    public List<String> history() {
+        List<String> result = new ArrayList<>();
         for (int i = 0; i < historySize; i++) {
-            System.out.println(history[i].toListString());
+            result.add(history[i].toListString());
         }
+        return result;
     }
 
     /**
@@ -81,7 +88,7 @@ public class Playlist {
      *
      * @param id identifier of the song(s) to remove
      */
-    public void removeById(int id) {
+    public int removeById(int id) {
         int amountRemoved = 0;
 
         if (currentSong != null && currentSong.getId() == id) {
@@ -105,9 +112,7 @@ public class Playlist {
             }
         }
 
-        if (amountRemoved > 0) {
-            System.out.println("Removed " + amountRemoved + " songs.");
-        }
+        return amountRemoved;
     }
 
     /**
@@ -205,18 +210,22 @@ public class Playlist {
 
 
     /**
-     * Prints all songs in the playlist ordered by priority, including the
+     * Collects all songs in the playlist ordered by priority, including the
      * currently playing song if present.
+     *
+     * @return list of formatted song strings
      */
-    public void list() {
+    public List<String> list() {
+        List<String> result = new ArrayList<>();
         for (int prio = 0; prio < 6; prio++) {
             if (currentSong != null && currentSong.getPriority() == prio) {
-                System.out.println(currentSong.toListString());
+                result.add(currentSong.toListString());
             }
             for (int i = 0; i < sizes[prio]; i++) {
-                System.out.println(queues[prio][i].toListString());
+                result.add(queues[prio][i].toListString());
             }
         }
+        return result;
     }
 
 

--- a/src/RemoveCommand.java
+++ b/src/RemoveCommand.java
@@ -11,6 +11,9 @@ public class RemoveCommand implements Command {
     @Override
     public void execute(String input, Playlist playlist) {
         int id = Integer.parseInt(input.substring(7).trim());
-        playlist.removeById(id);
+        int removed = playlist.removeById(id);
+        if (removed > 0) {
+            System.out.println("Removed " + removed + " songs.");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- make Playlist return formatted strings instead of printing
- print history, list and remove messages in their respective commands

## Testing
- `find src -name '*.java' -print0 | xargs -0 javac`
- `java -cp src Main <<'EOF'
add 1:artist1:title1:30:1
list
history
remove 1
list
quit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6852f94a4ff0832da94ebae4693ef991