### PR TITLE
Refine command exception handling

### DIFF
--- a/src/AddCommand.java
+++ b/src/AddCommand.java
@@ -14,7 +14,8 @@ public class AddCommand implements Command {
     }
 
     @Override
-    public void execute(String input, Playlist playlist) {
+    public void execute(String input, Playlist playlist)
+            throws IllegalArgumentException, NumberFormatException {
         Matcher m = PATTERN.matcher(input);
         if (m.matches()) {
             int id = Integer.parseInt(m.group(1));

--- a/src/Command.java
+++ b/src/Command.java
@@ -16,7 +16,9 @@ public interface Command {
      *
      * @param input the complete input line
      * @param playlist the playlist instance to operate on
-     * @throws Exception if parsing fails or a playlist error occurs
+     * @throws IllegalArgumentException if a parameter is invalid
+     * @throws NumberFormatException if numeric parsing fails
      */
-    void execute(String input, Playlist playlist) throws Exception;
+    void execute(String input, Playlist playlist)
+            throws IllegalArgumentException, NumberFormatException;
 }

--- a/src/CommandProcessor.java
+++ b/src/CommandProcessor.java
@@ -64,7 +64,9 @@ public class CommandProcessor {
                 if (cmd.matches(input)) {
                     try {
                         cmd.execute(input, playlist);
-                    } catch (Exception e) {
+                    } catch (NumberFormatException e) {
+                        System.out.println("\u26A0\uFE0F " + e.getMessage());
+                    } catch (IllegalArgumentException e) {
                         System.out.println("\u26A0\uFE0F " + e.getMessage());
                     }
                     handled = true;

--- a/src/HistoryCommand.java
+++ b/src/HistoryCommand.java
@@ -9,7 +9,8 @@ public class HistoryCommand implements Command {
     }
 
     @Override
-    public void execute(String input, Playlist playlist) {
+    public void execute(String input, Playlist playlist)
+            throws IllegalArgumentException, NumberFormatException {
         playlist.history();
     }
 }

--- a/src/ListCommand.java
+++ b/src/ListCommand.java
@@ -9,7 +9,8 @@ public class ListCommand implements Command {
     }
 
     @Override
-    public void execute(String input, Playlist playlist) {
+    public void execute(String input, Playlist playlist)
+            throws IllegalArgumentException, NumberFormatException {
         playlist.list();
     }
 }

--- a/src/NextCommand.java
+++ b/src/NextCommand.java
@@ -14,7 +14,8 @@ public class NextCommand implements Command {
     }
 
     @Override
-    public void execute(String input, Playlist playlist) {
+    public void execute(String input, Playlist playlist)
+            throws IllegalArgumentException, NumberFormatException {
         Matcher m = PATTERN.matcher(input);
         if (m.matches()) {
             int id = Integer.parseInt(m.group(1));

--- a/src/PeekCommand.java
+++ b/src/PeekCommand.java
@@ -9,7 +9,8 @@ public class PeekCommand implements Command {
     }
 
     @Override
-    public void execute(String input, Playlist playlist) {
+    public void execute(String input, Playlist playlist)
+            throws IllegalArgumentException, NumberFormatException {
         Song s = playlist.peek();
         if (s != null) {
             System.out.println(s.toPeekString());

--- a/src/PlayCommand.java
+++ b/src/PlayCommand.java
@@ -9,7 +9,8 @@ public class PlayCommand implements Command {
     }
 
     @Override
-    public void execute(String input, Playlist playlist) {
+    public void execute(String input, Playlist playlist)
+            throws IllegalArgumentException, NumberFormatException {
         int seconds = Integer.parseInt(input.substring(5).trim());
         playlist.play(seconds);
     }

--- a/src/QuitCommand.java
+++ b/src/QuitCommand.java
@@ -9,7 +9,8 @@ public class QuitCommand implements Command {
     }
 
     @Override
-    public void execute(String input, Playlist playlist) {
+    public void execute(String input, Playlist playlist)
+            throws IllegalArgumentException, NumberFormatException {
         System.out.println("\uD83D\uDC4B Bye!");
     }
 }

--- a/src/RemoveCommand.java
+++ b/src/RemoveCommand.java
@@ -9,7 +9,8 @@ public class RemoveCommand implements Command {
     }
 
     @Override
-    public void execute(String input, Playlist playlist) {
+    public void execute(String input, Playlist playlist)
+            throws IllegalArgumentException, NumberFormatException {
         int id = Integer.parseInt(input.substring(7).trim());
         playlist.removeById(id);
     }

--- a/src/SkipCommand.java
+++ b/src/SkipCommand.java
@@ -9,7 +9,8 @@ public class SkipCommand implements Command {
     }
 
     @Override
-    public void execute(String input, Playlist playlist) {
+    public void execute(String input, Playlist playlist)
+            throws IllegalArgumentException, NumberFormatException {
         playlist.skip();
     }
 }


### PR DESCRIPTION
## Summary
- narrow `Command.execute` to `IllegalArgumentException` and `NumberFormatException`
- declare these exceptions in each command implementation
- handle these exceptions in `CommandProcessor.run`
- update `Command` javadoc accordingly

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_6852f94ad854832dac255587c3e7e3fe