### PR TITLE
Remove checked exception from Command.execute

### DIFF
--- a/src/Command.java
+++ b/src/Command.java
@@ -16,7 +16,8 @@ public interface Command {
      *
      * @param input the complete input line
      * @param playlist the playlist instance to operate on
-     * @throws Exception if parsing fails or a playlist error occurs
+     * Implementations may throw a {@link RuntimeException} if parsing fails or
+     * a playlist error occurs.
      */
-    void execute(String input, Playlist playlist) throws Exception;
+    void execute(String input, Playlist playlist);
 }

--- a/src/CommandProcessor.java
+++ b/src/CommandProcessor.java
@@ -55,7 +55,7 @@ public class CommandProcessor {
                 if (cmd.matches(input)) {
                     try {
                         cmd.execute(input, playlist);
-                    } catch (Exception e) {
+                    } catch (RuntimeException e) {
                         System.out.println("\u26A0\uFE0F " + e.getMessage());
                     }
                     handled = true;


### PR DESCRIPTION
## Summary
- make `Command.execute` not declare `throws Exception`
- adjust `CommandProcessor` to catch only runtime exceptions

## Testing
- `javac src/*.java`

------
https://chatgpt.com/codex/tasks/task_e_6853424efa68832db519b9c4d90bcdd5