### PR TITLE
Improve SongParser docs and imports

### DIFF
--- a/src/SongParser.java
+++ b/src/SongParser.java
@@ -1,17 +1,34 @@
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Utility for converting text definitions into {@link Song} objects.
+ * The accepted formats correspond to the regular expressions exposed by
+ * this class so that command implementations can validate input.
+ */
 public final class SongParser {
     public static final String WITH_PRIORITY_REGEX = "(\\d+):([^:]+):([^:]+):(\\d+):(\\d+)";
     public static final String WITHOUT_PRIORITY_REGEX = "(\\d+):([^:]+):([^:]+):(\\d+)";
 
-    private static final java.util.regex.Pattern WITH_PRIORITY_PATTERN =
-            java.util.regex.Pattern.compile(WITH_PRIORITY_REGEX);
-    private static final java.util.regex.Pattern WITHOUT_PRIORITY_PATTERN =
-            java.util.regex.Pattern.compile(WITHOUT_PRIORITY_REGEX);
+    private static final Pattern WITH_PRIORITY_PATTERN =
+            Pattern.compile(WITH_PRIORITY_REGEX);
+    private static final Pattern WITHOUT_PRIORITY_PATTERN =
+            Pattern.compile(WITHOUT_PRIORITY_REGEX);
 
     private SongParser() {
     }
 
+    /**
+     * Parses a song definition that includes a priority.
+     * <p>
+     * Expected format: {@code id:artist:title:length:priority}
+     *
+     * @param input the string to parse
+     * @return the resulting {@link Song}
+     * @throws IllegalArgumentException if the input does not match the format
+     */
     public static Song parseWithPriority(String input) {
-        java.util.regex.Matcher m = WITH_PRIORITY_PATTERN.matcher(input);
+        Matcher m = WITH_PRIORITY_PATTERN.matcher(input);
         if (!m.matches()) {
             throw new IllegalArgumentException("Invalid song format");
         }
@@ -23,8 +40,18 @@ public final class SongParser {
         return new Song(id, artist, title, length, priority);
     }
 
+    /**
+     * Parses a song definition without a priority. The song will receive
+     * priority {@code 0}.
+     * <p>
+     * Expected format: {@code id:artist:title:length}
+     *
+     * @param input the string to parse
+     * @return the resulting {@link Song}
+     * @throws IllegalArgumentException if the input does not match the format
+     */
     public static Song parseWithoutPriority(String input) {
-        java.util.regex.Matcher m = WITHOUT_PRIORITY_PATTERN.matcher(input);
+        Matcher m = WITHOUT_PRIORITY_PATTERN.matcher(input);
         if (!m.matches()) {
             throw new IllegalArgumentException("Invalid song format");
         }


### PR DESCRIPTION
## Summary
- document the purpose of `SongParser`
- add JavaDocs for `parseWithPriority` and `parseWithoutPriority`
- replace fully qualified regex classes with imports

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_6853425a9708832d8149524e98fdfbff