### PR TITLE
Remove regex usage from command parsing

### DIFF
--- a/src/kastel/AddCommand.java
+++ b/src/kastel/AddCommand.java
@@ -1,29 +1,33 @@
 package kastel;
 
-import java.util.regex.Pattern;
-
 /**
  * Handles the "add" command that inserts a song into the playlist.
  * @author ujnaa
  */
 public class AddCommand implements Command {
-    private static final Pattern PATTERN = Pattern.compile("add\\s+" + SongParser.WITH_PRIORITY_REGEX);
-    private static final char SPACE = ' ';
-    private static final int SUBSTRING_OFFSET = 1;
+    private static final String PREFIX = "add ";
     private static final String INVALID_FORMAT_MESSAGE = "Invalid add command format";
 
     @Override
     public boolean matches(String input) {
-        return PATTERN.matcher(input).matches();
+        if (!input.startsWith(PREFIX)) {
+            return false;
+        }
+        String songDef = input.substring(PREFIX.length());
+        try {
+            SongParser.parseWithPriority(songDef);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 
     @Override
     public void execute(String input, Playlist playlist) {
-        int idx = input.indexOf(SPACE);
-        if (idx == -1) {
+        if (!matches(input)) {
             throw new IllegalArgumentException(INVALID_FORMAT_MESSAGE);
         }
-        String songDef = input.substring(idx + SUBSTRING_OFFSET);
+        String songDef = input.substring(PREFIX.length());
         playlist.addSong(SongParser.parseWithPriority(songDef));
     }
 }

--- a/src/kastel/NextCommand.java
+++ b/src/kastel/NextCommand.java
@@ -1,29 +1,33 @@
 package kastel;
 
-import java.util.regex.Pattern;
-
 /**
  * Handles the "next" command that schedules a song as the next track.
  * @author ujnaa
  */
 public class NextCommand implements Command {
-    private static final Pattern PATTERN = Pattern.compile("next\\s+" + SongParser.WITHOUT_PRIORITY_REGEX);
-    private static final char SPACE = ' ';
-    private static final int SUBSTRING_OFFSET = 1;
+    private static final String PREFIX = "next ";
     private static final String INVALID_FORMAT_MESSAGE = "Invalid next command format";
 
     @Override
     public boolean matches(String input) {
-        return PATTERN.matcher(input).matches();
+        if (!input.startsWith(PREFIX)) {
+            return false;
+        }
+        String songDef = input.substring(PREFIX.length());
+        try {
+            SongParser.parseWithoutPriority(songDef);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 
     @Override
     public void execute(String input, Playlist playlist) {
-        int idx = input.indexOf(SPACE);
-        if (idx == -1) {
+        if (!matches(input)) {
             throw new IllegalArgumentException(INVALID_FORMAT_MESSAGE);
         }
-        String songDef = input.substring(idx + SUBSTRING_OFFSET);
+        String songDef = input.substring(PREFIX.length());
         playlist.addNext(SongParser.parseWithoutPriority(songDef));
     }
 }

--- a/src/kastel/SongParser.java
+++ b/src/kastel/SongParser.java
@@ -1,58 +1,13 @@
 package kastel;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 /**
  * Utility for converting text definitions into {@link Song} objects.
- * The accepted formats correspond to the regular expressions exposed by
- * this class so that command implementations can validate input.
+ * Command implementations rely on this class to validate the expected
+ * input formats.
  * @author ujnaa
  */
 public final class SongParser {
-    /**
-     * Regular expression to parse song input with priority.
-     * <p>
-     * The expected format is:
-     * {@code <id>:<artist>:<title>:<length>:<priority>}
-     * where:
-     * <ul>
-     *   <li>{@code <id>} is a positive integer (song ID)</li>
-     *   <li>{@code <artist>} is the artist name (no colons)</li>
-     *   <li>{@code <title>} is the song title (no colons)</li>
-     *   <li>{@code <length>} is the duration of the song in seconds</li>
-     *   <li>{@code <priority>} is an integer between 0 (highest) and 5 (lowest)</li>
-     * </ul>
-     */
-    public static final String WITH_PRIORITY_REGEX = "(\\d+):([^:]+):([^:]+):(\\d+):(\\d+)";
-
-    /**
-     * Regular expression to parse song input without priority (used in `next` command).
-     * <p>
-     * The expected format is:
-     * {@code <id>:<artist>:<title>:<length>}
-     * where:
-     * <ul>
-     *   <li>{@code <id>} is a positive integer (song ID)</li>
-     *   <li>{@code <artist>} is the artist name (no colons)</li>
-     *   <li>{@code <title>} is the song title (no colons)</li>
-     *   <li>{@code <length>} is the duration of the song in seconds</li>
-     * </ul>
-     */
-    public static final String WITHOUT_PRIORITY_REGEX = "(\\d+):([^:]+):([^:]+):(\\d+)";
-
-
-    private static final Pattern WITH_PRIORITY_PATTERN =
-            Pattern.compile(WITH_PRIORITY_REGEX);
-    private static final Pattern WITHOUT_PRIORITY_PATTERN =
-            Pattern.compile(WITHOUT_PRIORITY_REGEX);
-
     private static final String INVALID_SONG_FORMAT = "Invalid song format";
-    private static final int GROUP_ID = 1;
-    private static final int GROUP_ARTIST = 2;
-    private static final int GROUP_TITLE = 3;
-    private static final int GROUP_LENGTH = 4;
-    private static final int GROUP_PRIORITY = 5;
     private static final int DEFAULT_PRIORITY = 0;
 
     private SongParser() {
@@ -69,16 +24,20 @@ public final class SongParser {
      */
 
     public static Song parseWithPriority(String input) {
-        Matcher m = WITH_PRIORITY_PATTERN.matcher(input);
-        if (!m.matches()) {
+        String[] parts = input.split(":", -1);
+        if (parts.length != 5) {
             throw new IllegalArgumentException(INVALID_SONG_FORMAT);
         }
-        int id = Integer.parseInt(m.group(GROUP_ID));
-        String artist = m.group(GROUP_ARTIST).trim();
-        String title = m.group(GROUP_TITLE).trim();
-        int length = Integer.parseInt(m.group(GROUP_LENGTH));
-        int priority = Integer.parseInt(m.group(GROUP_PRIORITY));
-        return new Song(id, artist, title, length, priority);
+        try {
+            int id = Integer.parseInt(parts[0]);
+            String artist = parts[1].trim();
+            String title = parts[2].trim();
+            int length = Integer.parseInt(parts[3]);
+            int priority = Integer.parseInt(parts[4]);
+            return new Song(id, artist, title, length, priority);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(INVALID_SONG_FORMAT);
+        }
     }
 
     /**
@@ -92,14 +51,18 @@ public final class SongParser {
      * @throws IllegalArgumentException if the input does not match the format
      */
     public static Song parseWithoutPriority(String input) {
-        Matcher m = WITHOUT_PRIORITY_PATTERN.matcher(input);
-        if (!m.matches()) {
+        String[] parts = input.split(":", -1);
+        if (parts.length != 4) {
             throw new IllegalArgumentException(INVALID_SONG_FORMAT);
         }
-        int id = Integer.parseInt(m.group(GROUP_ID));
-        String artist = m.group(GROUP_ARTIST).trim();
-        String title = m.group(GROUP_TITLE).trim();
-        int length = Integer.parseInt(m.group(GROUP_LENGTH));
-        return new Song(id, artist, title, length, DEFAULT_PRIORITY);
+        try {
+            int id = Integer.parseInt(parts[0]);
+            String artist = parts[1].trim();
+            String title = parts[2].trim();
+            int length = Integer.parseInt(parts[3]);
+            return new Song(id, artist, title, length, DEFAULT_PRIORITY);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(INVALID_SONG_FORMAT);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- remove `java.util.regex` imports and all regex usage
- parse song definitions using simple `split` logic
- update command classes to use the new parser

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_6853519d39f0832db49f007f76c74179